### PR TITLE
feat: dynamic terminals

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -6,6 +6,7 @@ IDEAS
 * Support multiple screens
 * At night hours make the "close tabs" function automatic
 * Show last activity info near input for comparison
+    * Additionaly it could suggest you to take a tomato break, after it detects that you have been having working nonstop.
 * Make it so you have to press a button to exit the tomato break screen. Locate this button alongside the other buttons (such as close tabs, and shutdown). The order of these buttons will be shuffled every time so the user has to make the concious desicion to press it instead of the others.
 * Allow internet usage in intervals of 5 minutes (ON/OFF).
 * Make it so that for each minute without internet, you get a minute (or two) with internet. You start with 5 minutes each session.
@@ -14,12 +15,17 @@ IDEAS
 * Add "tomato break" option to tray icon, this option would end the session and enter a tomato break.
 * The ability to lock the sticky module in place.
 * After setting a task to take more than 30 minutes, the next immediate task must be less than 30 minutes. This would discourage chaining long lasting tasks together (very common when procrastinating), and encourage to pick better scoped tasks.
+* A "need youtube" setting. This would require integrating the "Youtube puzzle" web extension.
+* When the work session is about to end. Use visual cues in sticky, like Hyperfocus does.
 
 OVERLAY IDEAS
 
     * Alongside the "need internet" button, add a "shutdown on finish" button.
     * Put something visually attractive in the tomato break screen, so that you don't look away and ignore the action buttons.
+        * I was thinking about a picture a thinking roman statue.
     * Terminal on it's own tab, so that the user has a big area to work with. It's always and ideal scenario if the task can be done on the terminal.
+        * The user could continue their work session inside and outside aboutlife's overlay, using terminal multiplexer tools like tmux, screen, tywm.
+        * For users that prefer grafical tiling window managers instead of terminal multiplexers a special application/compatibility/translator/state tool could be developed for that use case.
     * A module to visualize your pomodoro sessions and breaks.
     * task manager: A section that shows a list of the opened apps with icons and thumbnails and a way to close them.
     * Alternatively from being able to specify a custom "task". Allow the creation of "goals", goals are displayed in a list, so, the user can choose to work on a specific goal.
@@ -31,6 +37,7 @@ OVERLAY IDEAS
     * Once in a while, after you obligatory break screen ends, you will get to a different screen with a 1 minute countdown, a message: "We're closing your webpages.. Take a break.", a button: "Acelerate closing", and another button: "Keep my pages this time". This last button you have to click very quickly to fill a bar, if you stop clicking the bar slowly returns back to zero.
         * The idea is, to keep your pages you have to make an extra effort. But to automatically remove them just relax and do nothing.
         * Maybe some motivational images could show during the event. I'm thinking on making a reusable image viewer widget that could be embedded in other relevant screens.
+    * Increase the obligatory break time at late hours (like do nothing for 2 minutes webpage)
 
 DONE
 

--- a/aboutlife/overlay/custom.css
+++ b/aboutlife/overlay/custom.css
@@ -1,0 +1,12 @@
+* {
+  -gtk-icon-effect: none;
+  box-shadow: none;
+}
+
+.term {
+  padding-left: 3px;
+}
+
+.term-selected {
+  background: #D7B745;
+}

--- a/aboutlife/overlay/overlay.py
+++ b/aboutlife/overlay/overlay.py
@@ -191,8 +191,29 @@ class OverlayPlugin(Plugin):
         elif event.keyval == Gdk.KEY_2:
             if current != NOTEBOOK.TERMINALS.value:
                 GLib.idle_add(self.notebook.set_current_page, NOTEBOOK.TERMINALS.value)
+                self.cycle_terminal_focus(0)
+            return True
+        elif event.keyval == Gdk.KEY_j:
+            self.cycle_terminal_focus(1)
+            return True
+        elif event.keyval == Gdk.KEY_k:
+            self.cycle_terminal_focus(-1)
             return True
         return False
+
+    def cycle_terminal_focus(self, step: int):
+        # get which term is focused
+        selected_term = -1
+        for i in range(MAX_TERMS):
+            if self.terms[i] == self.main_window.get_focus():
+                selected_term = i
+                break
+
+        # select next term or prior
+        next_term = (selected_term + step) % MAX_TERMS
+        if selected_term == -1:
+            next_term = 0
+        self.terms[next_term].grab_focus()
 
     def process(self):
         self.tick += 1

--- a/aboutlife/overlay/overlay.py
+++ b/aboutlife/overlay/overlay.py
@@ -140,22 +140,25 @@ class OverlayPlugin(Plugin):
 
         overlay_w = self.multiplexer.get_allocated_width()
         overlay_h = self.multiplexer.get_allocated_height()
+        gap = 4
 
         # main
         box = self.terms[0].get_parent()
         GLib.idle_add(box.set_margin_top, 0)
         GLib.idle_add(box.set_margin_bottom, 0)
         GLib.idle_add(box.set_margin_start, 0)
-        GLib.idle_add(box.set_margin_end, overlay_w / 2)
+        GLib.idle_add(box.set_margin_end, overlay_w/2 + gap/2)
 
         # slaves
         slave_h = overlay_h / (MAX_TERMS - 1)
         for i in range(1, MAX_TERMS):
             print(f"Configuring terminal {i}")
             box = self.terms[i].get_parent()
-            GLib.idle_add(box.set_margin_top, slave_h * (i - 1))
-            GLib.idle_add(box.set_margin_bottom, slave_h * (MAX_TERMS - 1 - i))
-            GLib.idle_add(box.set_margin_start, overlay_w / 2)
+            margin_top = slave_h * (i - 1) + (gap/2 if i != 1 else 0)
+            margin_bot = slave_h * (MAX_TERMS - 1 - i) + (gap/2 if i != MAX_TERMS-1 else 0)
+            GLib.idle_add(box.set_margin_top, margin_top)
+            GLib.idle_add(box.set_margin_bottom, margin_bot)
+            GLib.idle_add(box.set_margin_start, overlay_w / 2 + gap/2)
             GLib.idle_add(box.set_margin_end, 0)
 
     def process(self):

--- a/aboutlife/overlay/overlay.py
+++ b/aboutlife/overlay/overlay.py
@@ -40,7 +40,7 @@ class OverlayPlugin(Plugin):
 
         self.main_window = builder.get_object("main-window")
         self.main_window.connect("destroy", Gtk.main_quit)
-        self.main_window.connect("show", self.reset)
+        self.main_window.connect("show", self.on_show)
         self.main_window.connect("delete-event", lambda x, y: True)
 
         self.notebook = builder.get_object("main-notebook")
@@ -97,18 +97,18 @@ class OverlayPlugin(Plugin):
         settings = Gtk.Settings.get_default()
         settings.set_property("gtk-application-prefer-dark-theme", True)
 
-        # grab keyboard
-        thread = threading.Thread(target=keygrab_loop, args=(self.main_window,))
-        thread.daemon = True
-        thread.start()
-
         # start
         self.main_window.show_all()
         self.focus_window.show_all()
         self.ready = True
         Gtk.main()
 
-    def reset(self, widget):
+    def on_show(self, widget):
+        # grab keyboard
+        thread = threading.Thread(target=keygrab_loop, args=(self.main_window,))
+        thread.daemon = True
+        thread.start()
+
         print("D: Starting setting up terminal")
         self.terminal.spawn_sync(
             Vte.PtyFlags.DEFAULT,

--- a/aboutlife/overlay/overlay.py
+++ b/aboutlife/overlay/overlay.py
@@ -47,6 +47,7 @@ class OverlayPlugin(Plugin):
         self.multiplexer = None
 
     def setup(self):
+        # build
         builder = Gtk.Builder()
         builder.add_from_file(get_resource_path("/overlay/ui.glade"))
         builder.connect_signals(self)
@@ -74,9 +75,12 @@ class OverlayPlugin(Plugin):
         self.lbl_waiting = builder.get_object("lbl-waiting")
         self.multiplexer = builder.get_object("multiplexer")
 
+        # initial configuration
         self.tbx_task.set_placeholder_text(f"Mínimo {TASK_MIN_LENGTH} letras")
         self.tbx_task.set_max_length(TASK_MAX_LENGTH)
         self.notebook.set_current_page(NOTEBOOK.SETUP.value)
+        self.lbl_time.set_text("")
+        self.lbl_waiting.set_text("")
 
         # create terminals
         for i in range(MAX_TERMS):

--- a/aboutlife/overlay/overlay.py
+++ b/aboutlife/overlay/overlay.py
@@ -44,7 +44,9 @@ class OverlayPlugin(Plugin):
         self.main_window.connect("delete-event", lambda x, y: True)
 
         self.notebook = builder.get_object("main-notebook")
-        self.terminal = builder.get_object("terminal")
+        term_container = builder.get_object("term-container")
+        self.terminal = Vte.Terminal()
+        term_container.add(self.terminal)
         self.tbx_task = builder.get_object("tbx-task")
         self.cbx_duration = builder.get_object("cbx-duration")
         self.swi_network = builder.get_object("swi-network")
@@ -90,7 +92,6 @@ class OverlayPlugin(Plugin):
         self.main_window.set_skip_pager_hint(True)
         self.main_window.set_keep_above(True)
         self.main_window.set_decorated(False)
-        self.main_window.present()
         self.main_window.stick()
 
         # prefer dark theme

--- a/aboutlife/overlay/ui.glade
+++ b/aboutlife/overlay/ui.glade
@@ -38,39 +38,6 @@
                     <child>
                       <placeholder/>
                     </child>
-                    <child>
-                      <object class="GtkRadioButton" id="radiobutton2">
-                        <property name="label" translatable="yes">Inicio</property>
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="focus-on-click">False</property>
-                        <property name="receives-default">False</property>
-                        <property name="active">True</property>
-                        <property name="draw-indicator">True</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkRadioButton">
-                        <property name="label" translatable="yes">Terminales</property>
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="focus-on-click">False</property>
-                        <property name="receives-default">False</property>
-                        <property name="active">True</property>
-                        <property name="draw-indicator">True</property>
-                        <property name="group">radiobutton2</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">3</property>
-                      </packing>
-                    </child>
                   </object>
                   <packing>
                     <property name="expand">True</property>

--- a/aboutlife/overlay/ui.glade
+++ b/aboutlife/overlay/ui.glade
@@ -580,7 +580,6 @@
                               <object class="GtkLabel">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">:)</property>
                               </object>
                               <packing>
                                 <property name="index">-1</property>

--- a/aboutlife/overlay/ui.glade
+++ b/aboutlife/overlay/ui.glade
@@ -369,18 +369,6 @@
                                   <object class="GtkAlignment" id="term-container">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <child>
-                                      <object class="VteTerminal" id="terminal">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="hscroll_policy">natural</property>
-                                        <property name="vscroll_policy">natural</property>
-                                        <property name="encoding">UTF-8</property>
-                                        <property name="scroll_on_keystroke">True</property>
-                                        <property name="scroll_on_output">False</property>
-                                        <property name="font_scale">1.2</property>
-                                      </object>
-                                    </child>
                                   </object>
                                 </child>
                                 <child type="label_item">

--- a/aboutlife/overlay/ui.glade
+++ b/aboutlife/overlay/ui.glade
@@ -128,6 +128,7 @@
                       <object class="GtkNotebook" id="main-notebook">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="show-tabs">False</property>
                         <property name="show-border">False</property>
                         <child>
                           <!-- n-columns=2 n-rows=2 -->

--- a/aboutlife/overlay/ui.glade
+++ b/aboutlife/overlay/ui.glade
@@ -2,22 +2,20 @@
 <!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
+  <!-- interface-css-provider-path custom.css -->
   <object class="GtkWindow" id="main-window">
     <property name="can-focus">False</property>
     <property name="type">popup</property>
     <property name="default-width">1280</property>
     <property name="default-height">720</property>
-    <property name="type-hint">tooltip</property>
     <child>
       <object class="GtkAlignment">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <property name="xscale">0.699999988079071</property>
-        <property name="yscale">0.699999988079071</property>
         <property name="top-padding">40</property>
         <property name="bottom-padding">40</property>
-        <property name="left-padding">40</property>
-        <property name="right-padding">40</property>
+        <property name="left-padding">80</property>
+        <property name="right-padding">80</property>
         <child>
           <object class="GtkBox">
             <property name="visible">True</property>
@@ -29,26 +27,53 @@
               <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
+                <property name="spacing">2</property>
                 <property name="homogeneous">True</property>
                 <child>
-                  <object class="GtkLabel" id="lbl-waiting">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="halign">end</property>
+                    <property name="spacing">5</property>
+                    <property name="baseline-position">top</property>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <object class="GtkRadioButton" id="radiobutton2">
+                        <property name="label" translatable="yes">Inicio</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="focus-on-click">False</property>
+                        <property name="receives-default">False</property>
+                        <property name="active">True</property>
+                        <property name="draw-indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRadioButton">
+                        <property name="label" translatable="yes">Terminales</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="focus-on-click">False</property>
+                        <property name="receives-default">False</property>
+                        <property name="active">True</property>
+                        <property name="draw-indicator">True</property>
+                        <property name="group">radiobutton2</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">-1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
+                    <property name="expand">True</property>
                     <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>
@@ -58,15 +83,29 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="halign">center</property>
+                    <property name="label" translatable="yes">hour and date</property>
                     <property name="justify">fill</property>
                     <attributes>
                       <attribute name="scale" value="1"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
+                    <property name="expand">True</property>
                     <property name="fill">True</property>
                     <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="lbl-waiting">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">5:20</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
               </object>
@@ -81,37 +120,377 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <child>
-                  <object class="GtkNotebook" id="main-notebook">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="show-tabs">False</property>
-                    <property name="show-border">False</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkLabel">
+                      <object class="GtkNotebook" id="main-notebook">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">Conectando</property>
-                      </object>
-                    </child>
-                    <child type="tab">
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">One</property>
-                      </object>
-                      <packing>
-                        <property name="tab-fill">False</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <!-- n-columns=2 n-rows=2 -->
-                      <object class="GtkGrid">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="row-spacing">10</property>
-                        <property name="column-spacing">10</property>
-                        <property name="row-homogeneous">True</property>
-                        <property name="column-homogeneous">True</property>
+                        <property name="show-border">False</property>
+                        <child>
+                          <!-- n-columns=2 n-rows=2 -->
+                          <object class="GtkGrid">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="row-spacing">10</property>
+                            <property name="column-spacing">10</property>
+                            <property name="row-homogeneous">True</property>
+                            <property name="column-homogeneous">True</property>
+                            <child>
+                              <object class="GtkFrame">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0</property>
+                                <property name="shadow-type">out</property>
+                                <child>
+                                  <object class="GtkAlignment">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="xscale">0.009999999776482582</property>
+                                    <property name="yscale">0.009999999776482582</property>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="spacing">10</property>
+                                        <property name="homogeneous">True</property>
+                                        <child>
+                                          <object class="GtkButton" id="btn-close-tabs-1">
+                                            <property name="label" translatable="yes">Cerrar pestañas</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkButton" id="btn-shutdown-1">
+                                            <property name="label" translatable="yes">Apagar computadora</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkButton" id="btn-tomato-1">
+                                            <property name="label" translatable="yes">Descanso de tomate</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">3</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label_item">
+                                  <placeholder/>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFrame">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0</property>
+                                <property name="shadow-type">out</property>
+                                <child>
+                                  <object class="GtkAlignment">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="xscale">0.009999999776482582</property>
+                                    <property name="yscale">0.009999999776482582</property>
+                                    <child>
+                                      <!-- n-columns=2 n-rows=4 -->
+                                      <object class="GtkGrid">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="row-spacing">10</property>
+                                        <property name="column-spacing">10</property>
+                                        <property name="row-homogeneous">True</property>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="halign">end</property>
+                                            <property name="label" translatable="yes">¿Qué vas a hacer?</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkEntry" id="tbx-task">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="has-focus">True</property>
+                                            <property name="is-focus">True</property>
+                                            <property name="width-chars">28</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="halign">end</property>
+                                            <property name="label" translatable="yes">Duración (minutos)</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkButton" id="btn-start-session">
+                                            <property name="label" translatable="yes">Empezar</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">3</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <child>
+                                              <object class="GtkComboBoxText" id="cbx-duration">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="focus-on-click">False</property>
+                                                <property name="button-sensitivity">off</property>
+                                                <items>
+                                                  <item translatable="yes">1</item>
+                                                  <item translatable="yes">5</item>
+                                                  <item translatable="yes">7</item>
+                                                  <item translatable="yes">10</item>
+                                                  <item translatable="yes">12</item>
+                                                  <item translatable="yes">15</item>
+                                                  <item translatable="yes">20</item>
+                                                  <item translatable="yes">25</item>
+                                                  <item translatable="yes">30</item>
+                                                  <item translatable="yes">50</item>
+                                                </items>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">True</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkButton" id="btn-duration-up">
+                                                <property name="label" translatable="yes">⮝</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="relief">none</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkButton" id="btn-duration-down">
+                                                <property name="label" translatable="yes">⮟</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="relief">none</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="halign">end</property>
+                                            <property name="label" translatable="yes">¿Necesita internet?</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSwitch" id="swi-network">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="halign">start</property>
+                                            <property name="valign">center</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label_item">
+                                  <placeholder/>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkFrame">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label-xalign">0</property>
+                                    <property name="shadow-type">out</property>
+                                    <child>
+                                      <object class="GtkAlignment" id="term-container">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                      </object>
+                                    </child>
+                                    <child type="label_item">
+                                      <placeholder/>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <child>
+                                      <object class="GtkScrolledWindow">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="hscrollbar-policy">external</property>
+                                        <property name="vscrollbar-policy">external</property>
+                                        <property name="window-placement">bottom-right</property>
+                                        <property name="shadow-type">in</property>
+                                        <property name="min-content-height">80</property>
+                                        <property name="kinetic-scrolling">False</property>
+                                        <property name="overlay-scrolling">False</property>
+                                        <property name="propagate-natural-width">True</property>
+                                        <child>
+                                          <object class="GtkViewport">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <child>
+                                              <object class="GtkImage">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="pixbuf">freenaturestock-2124-cropped.jpg</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">0</property>
+                                <property name="height">2</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                        <child type="tab">
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">One</property>
+                          </object>
+                          <packing>
+                            <property name="tab-fill">False</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Conectando</property>
+                          </object>
+                          <packing>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child type="tab">
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Two</property>
+                          </object>
+                          <packing>
+                            <property name="position">1</property>
+                            <property name="tab-fill">False</property>
+                          </packing>
+                        </child>
                         <child>
                           <object class="GtkFrame">
                             <property name="visible">True</property>
@@ -132,11 +511,10 @@
                                     <property name="spacing">10</property>
                                     <property name="homogeneous">True</property>
                                     <child>
-                                      <object class="GtkButton" id="btn-close-tabs-1">
-                                        <property name="label" translatable="yes">Cerrar pestañas</property>
+                                      <object class="GtkLabel">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">I am injury</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -145,8 +523,8 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkButton" id="btn-shutdown-1">
-                                        <property name="label" translatable="yes">Apagar computadora</property>
+                                      <object class="GtkButton" id="btn-close-tabs-2">
+                                        <property name="label" translatable="yes">Cerrar pestañas</property>
                                         <property name="visible">True</property>
                                         <property name="can-focus">True</property>
                                         <property name="receives-default">True</property>
@@ -158,8 +536,8 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkButton" id="btn-tomato-1">
-                                        <property name="label" translatable="yes">Descanso de tomate</property>
+                                      <object class="GtkButton" id="btn-shutdown-2">
+                                        <property name="label" translatable="yes">Apagar computadora</property>
                                         <property name="visible">True</property>
                                         <property name="can-focus">True</property>
                                         <property name="receives-default">True</property>
@@ -167,7 +545,7 @@
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
-                                        <property name="position">3</property>
+                                        <property name="position">2</property>
                                       </packing>
                                     </child>
                                   </object>
@@ -179,352 +557,143 @@
                             </child>
                           </object>
                           <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">1</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child type="tab">
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Three</property>
+                          </object>
+                          <packing>
+                            <property name="position">2</property>
+                            <property name="tab-fill">False</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkFrame">
+                          <object class="GtkOverlay" id="multiplexer">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="label-xalign">0</property>
-                            <property name="shadow-type">out</property>
+                            <property name="resize-mode">immediate</property>
                             <child>
-                              <object class="GtkAlignment">
+                              <object class="GtkLabel">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="xscale">0.009999999776482582</property>
-                                <property name="yscale">0.009999999776482582</property>
-                                <child>
-                                  <!-- n-columns=2 n-rows=4 -->
-                                  <object class="GtkGrid">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="row-spacing">10</property>
-                                    <property name="column-spacing">10</property>
-                                    <property name="row-homogeneous">True</property>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="halign">end</property>
-                                        <property name="label" translatable="yes">¿Qué vas a hacer?</property>
-                                      </object>
-                                      <packing>
-                                        <property name="left-attach">0</property>
-                                        <property name="top-attach">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkEntry" id="tbx-task">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="width-chars">28</property>
-                                        <property name="text" translatable="yes"></property>
-                                      </object>
-                                      <packing>
-                                        <property name="left-attach">1</property>
-                                        <property name="top-attach">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="halign">end</property>
-                                        <property name="label" translatable="yes">Duración (minutos)</property>
-                                      </object>
-                                      <packing>
-                                        <property name="left-attach">0</property>
-                                        <property name="top-attach">1</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkButton" id="btn-start-session">
-                                        <property name="label" translatable="yes">Empezar</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="left-attach">1</property>
-                                        <property name="top-attach">3</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <child>
-                                          <object class="GtkComboBoxText" id="cbx-duration">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="focus-on-click">False</property>
-                                            <property name="button-sensitivity">off</property>
-                                            <items>
-                                              <item translatable="yes">1</item>
-                                              <item translatable="yes">5</item>
-                                              <item translatable="yes">7</item>
-                                              <item translatable="yes">10</item>
-                                              <item translatable="yes">12</item>
-                                              <item translatable="yes">15</item>
-                                              <item translatable="yes">20</item>
-                                              <item translatable="yes">25</item>
-                                              <item translatable="yes">30</item>
-                                              <item translatable="yes">50</item>
-                                            </items>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">True</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButton" id="btn-duration-up">
-                                            <property name="label" translatable="yes">⮝</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">True</property>
-                                            <property name="relief">none</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButton" id="btn-duration-down">
-                                            <property name="label" translatable="yes">⮟</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">True</property>
-                                            <property name="relief">none</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">2</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="left-attach">1</property>
-                                        <property name="top-attach">1</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="halign">end</property>
-                                        <property name="label" translatable="yes">¿Necesita internet?</property>
-                                      </object>
-                                      <packing>
-                                        <property name="left-attach">0</property>
-                                        <property name="top-attach">2</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSwitch" id="swi-network">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="halign">start</property>
-                                        <property name="valign">center</property>
-                                      </object>
-                                      <packing>
-                                        <property name="left-attach">1</property>
-                                        <property name="top-attach">2</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                  </object>
-                                </child>
+                                <property name="label" translatable="yes">:)</property>
                               </object>
+                              <packing>
+                                <property name="index">-1</property>
+                              </packing>
                             </child>
-                            <child type="label_item">
-                              <placeholder/>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="orientation">vertical</property>
-                            <child>
-                              <object class="GtkFrame">
+                            <child type="overlay">
+                              <object class="GtkFrame" id="term-4">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0</property>
-                                <property name="shadow-type">out</property>
+                                <property name="label-yalign">0</property>
+                                <property name="shadow-type">in</property>
                                 <child>
-                                  <object class="GtkAlignment" id="term-container">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                  </object>
+                                  <placeholder/>
+                                </child>
+                                <child type="label_item">
+                                  <placeholder/>
+                                </child>
+                              </object>
+                            </child>
+                            <child type="overlay">
+                              <object class="GtkFrame" id="term-3">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0</property>
+                                <property name="label-yalign">0</property>
+                                <property name="shadow-type">in</property>
+                                <child>
+                                  <placeholder/>
                                 </child>
                                 <child type="label_item">
                                   <placeholder/>
                                 </child>
                               </object>
                               <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
+                                <property name="index">1</property>
                               </packing>
                             </child>
-                            <child>
-                              <object class="GtkBox">
+                            <child type="overlay">
+                              <object class="GtkFrame" id="term-2">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
+                                <property name="label-xalign">0</property>
+                                <property name="label-yalign">0</property>
+                                <property name="shadow-type">in</property>
                                 <child>
-                                  <object class="GtkScrolledWindow">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="hscrollbar-policy">external</property>
-                                    <property name="vscrollbar-policy">external</property>
-                                    <property name="window-placement">bottom-right</property>
-                                    <property name="shadow-type">in</property>
-                                    <property name="min-content-height">80</property>
-                                    <property name="kinetic-scrolling">False</property>
-                                    <property name="overlay-scrolling">False</property>
-                                    <property name="propagate-natural-width">True</property>
-                                    <child>
-                                      <object class="GtkViewport">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <child>
-                                          <object class="GtkImage">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="pixbuf">freenaturestock-2124-cropped.jpg</property>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">True</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
+                                  <placeholder/>
+                                </child>
+                                <child type="label_item">
+                                  <placeholder/>
                                 </child>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
+                                <property name="index">2</property>
+                              </packing>
+                            </child>
+                            <child type="overlay">
+                              <object class="GtkFrame" id="term-1">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0</property>
+                                <property name="label-yalign">0</property>
+                                <property name="shadow-type">in</property>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child type="label_item">
+                                  <placeholder/>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="index">3</property>
+                              </packing>
+                            </child>
+                            <child type="overlay">
+                              <object class="GtkFrame" id="term-0">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0</property>
+                                <property name="label-yalign">0</property>
+                                <property name="shadow-type">in</property>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child type="label_item">
+                                  <placeholder/>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="index">4</property>
                               </packing>
                             </child>
                           </object>
                           <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">0</property>
-                            <property name="height">2</property>
+                            <property name="position">3</property>
+                          </packing>
+                        </child>
+                        <child type="tab">
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Four</property>
+                          </object>
+                          <packing>
+                            <property name="position">3</property>
+                            <property name="tab-fill">False</property>
                           </packing>
                         </child>
                       </object>
                       <packing>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child type="tab">
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">Two</property>
-                      </object>
-                      <packing>
-                        <property name="position">1</property>
-                        <property name="tab-fill">False</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkFrame">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="label-xalign">0</property>
-                        <property name="shadow-type">out</property>
-                        <child>
-                          <object class="GtkAlignment">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="xscale">0.009999999776482582</property>
-                            <property name="yscale">0.009999999776482582</property>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="orientation">vertical</property>
-                                <property name="spacing">10</property>
-                                <property name="homogeneous">True</property>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">I am injury</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkButton" id="btn-close-tabs-2">
-                                    <property name="label" translatable="yes">Cerrar pestañas</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkButton" id="btn-shutdown-2">
-                                    <property name="label" translatable="yes">Apagar computadora</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">2</property>
-                                  </packing>
-                                </child>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                        <child type="label_item">
-                          <placeholder/>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
-                    <child type="tab">
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">Three</property>
-                      </object>
-                      <packing>
-                        <property name="position">2</property>
-                        <property name="tab-fill">False</property>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
                       </packing>
                     </child>
                   </object>

--- a/aboutlife/overlay/ui.glade
+++ b/aboutlife/overlay/ui.glade
@@ -592,13 +592,16 @@
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0</property>
                                 <property name="label-yalign">0</property>
-                                <property name="shadow-type">in</property>
+                                <property name="shadow-type">none</property>
                                 <child>
                                   <placeholder/>
                                 </child>
                                 <child type="label_item">
                                   <placeholder/>
                                 </child>
+                                <style>
+                                  <class name="term"/>
+                                </style>
                               </object>
                             </child>
                             <child type="overlay">
@@ -607,13 +610,16 @@
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0</property>
                                 <property name="label-yalign">0</property>
-                                <property name="shadow-type">in</property>
+                                <property name="shadow-type">none</property>
                                 <child>
                                   <placeholder/>
                                 </child>
                                 <child type="label_item">
                                   <placeholder/>
                                 </child>
+                                <style>
+                                  <class name="term"/>
+                                </style>
                               </object>
                               <packing>
                                 <property name="index">1</property>
@@ -625,13 +631,16 @@
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0</property>
                                 <property name="label-yalign">0</property>
-                                <property name="shadow-type">in</property>
+                                <property name="shadow-type">none</property>
                                 <child>
                                   <placeholder/>
                                 </child>
                                 <child type="label_item">
                                   <placeholder/>
                                 </child>
+                                <style>
+                                  <class name="term"/>
+                                </style>
                               </object>
                               <packing>
                                 <property name="index">2</property>
@@ -643,13 +652,16 @@
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0</property>
                                 <property name="label-yalign">0</property>
-                                <property name="shadow-type">in</property>
+                                <property name="shadow-type">none</property>
                                 <child>
                                   <placeholder/>
                                 </child>
                                 <child type="label_item">
                                   <placeholder/>
                                 </child>
+                                <style>
+                                  <class name="term"/>
+                                </style>
                               </object>
                               <packing>
                                 <property name="index">3</property>
@@ -661,13 +673,16 @@
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0</property>
                                 <property name="label-yalign">0</property>
-                                <property name="shadow-type">in</property>
+                                <property name="shadow-type">none</property>
                                 <child>
                                   <placeholder/>
                                 </child>
                                 <child type="label_item">
                                   <placeholder/>
                                 </child>
+                                <style>
+                                  <class name="term"/>
+                                </style>
                               </object>
                               <packing>
                                 <property name="index">4</property>

--- a/aboutlife/utils.py
+++ b/aboutlife/utils.py
@@ -8,7 +8,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 ORIGIN_PATH = os.path.dirname(os.path.realpath(__file__))
-GRAB_TIMEOUT = 5
+GRAB_DURATION = 5
 IDLE_TIMEOUT = 0.2
 
 
@@ -27,13 +27,13 @@ def send_notification(title: str, message: str):
         subprocess.run(["notify-send", "-r", "108", "-t", "1000", title, message])
 
 
-# If there are no keyboard events in a while release it for a moment then grab
-# it again, so that the screensaver can take over
+# * If there are no keyboard events in a while release it for a moment then grab
+#   it again, so that the screensaver can take over
+# * It's assumed arg_window is ready (use 'show' signal)
 def keygrab_loop(arg_window: Gtk.Window):
     disp = display.Display()
     root = disp.screen().root
-    xid = arg_window.get_window().get_xid()
-    window = disp.create_resource_object("window", xid)
+    window = disp.create_resource_object("window", arg_window.get_window().get_xid())
     last_input_time: int = 0
     event_n = None
 
@@ -45,7 +45,7 @@ def keygrab_loop(arg_window: Gtk.Window):
             continue
 
         last_input_time = curr_time()
-        while (curr_time() - last_input_time) < GRAB_TIMEOUT:
+        while (curr_time() - last_input_time) < GRAB_DURATION:
             if disp.pending_events() > 0:
                 # handle events
                 last_input_time = curr_time()


### PR DESCRIPTION
Changes:
- New "terminals" workspace with 3 terminals (up to 5)
- Keybind to switch workspaces: `(Super+1)` for *home*, `(Super+2)` for *terminals*
- Keybind to switch between terminals, back and forth: `(Super+j)` forward, `(Super+k)` backwards